### PR TITLE
[rSHUD] Migrate key GIS APIs to sf/terra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ Rplots.pdf
 test*.R
 test2*.R
 nosync
+
+# Keep testthat tests tracked (override the broad test*.R ignore)
+!tests/testthat.R
+!tests/testthat/test-*.R
+
+# R CMD check artifacts
+..Rcheck/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,11 +23,9 @@ Imports: Rcpp,
   xts, 
   hydroGOF,
   zoo,
-  raster (>= 2.1.0), 
-  sp, 
-  rgeos, 
+  sf,
+  terra,
   RTriangle,
-  proj4,
   gstat,
   abind,
   utils,
@@ -35,15 +33,19 @@ Imports: Rcpp,
   doParallel,
   geometry,
   methods
-LinkingTo: Rcpp, sp
+LinkingTo: Rcpp
 RoxygenNote: 7.2.1
 Remotes: shulele/RTriangle/pkg
 Suggests: testthat,
     knitr,
     rmarkdown,
-    terra,
   deldir,
   interp,
   whitebox,
-  ncdf4
+  ncdf4,
+  sp,
+  raster,
+  rgdal,
+  rgeos,
+  proj4
 VignetteBuilder: knitr

--- a/R/GIS_Projection.R
+++ b/R/GIS_Projection.R
@@ -7,31 +7,32 @@
 #' @examples
 #' crs.Albers(ext=c(90, 100, 35, 40))
 crs.Albers <- function(spx, ext=NULL){
-  if(is.null(ext)){
-    crs0 = sp::CRS('+init=epsg:4326')
-    sp.gcs = sp::spTransform(spx, crs0)
-    ext= raster::extent(sp.gcs)
+  if (is.null(ext)) {
+    if (missing(spx) || is.null(spx)) stop("crs.Albers: require spx or ext")
+    sp_sf <- .rshud_as_sf(spx)
+    sp_gcs <- sf::st_transform(sp_sf, 4326)
+    bb <- sf::st_bbox(sp_gcs)
+    ext <- c(bb[["xmin"]], bb[["xmax"]], bb[["ymin"]], bb[["ymax"]])
   }
-  x0 = round(mean(ext[1:2]), 1)
-  y0 = round(mean(ext[1:2+2]), 1)
-  dx = round(diff(ext[1:2]), 2)
-  dy = round(diff(ext[1:2+2]), 2)
-  if(dx < 1){
-    my = 0.25
-  }else{
-    my=round(dy/4, 2)
-  }
-  lat1 = y0 + my
-  lat2 = y0 - my
-  str = paste0(' +proj=', 'aea',
-               ' +lat_1=', lat1,
-               ' +lat_2=', lat2,
-               ' +lon_0=', x0,
-               ' +datum=', 'WGS84',
-               " +units=", "m"
+
+  x0 <- round(mean(ext[1:2]), 1)
+  y0 <- round(mean(ext[3:4]), 1)
+  dx <- round(diff(ext[1:2]), 2)
+  dy <- round(diff(ext[3:4]), 2)
+  my <- if (dx < 1) 0.25 else round(dy / 4, 2)
+
+  lat1 <- y0 + my
+  lat2 <- y0 - my
+  str <- paste0(
+    " +proj=aea",
+    " +lat_1=", lat1,
+    " +lat_2=", lat2,
+    " +lon_0=", x0,
+    " +datum=WGS84",
+    " +units=m"
   )
   print(str)
-  ret = sp::CRS(str)
+  ret <- sf::st_crs(str)
   return(ret)
 }
 #' Build a Lambert Equal Area projection based on the spatial data or extent.
@@ -43,21 +44,24 @@ crs.Albers <- function(spx, ext=NULL){
 #' @examples
 #' crs.Lambert(ext=c(90, 100, 35, 40))
 crs.Lambert <- function(spx, ext=NULL){
-  if(is.null(ext)){
-    crs0 = sp::CRS('+init=epsg:4326')
-    sp.gcs = sp::spTransform(spx, crs0)
-    ext= raster::extent(sp.gcs)
+  if (is.null(ext)) {
+    if (missing(spx) || is.null(spx)) stop("crs.Lambert: require spx or ext")
+    sp_sf <- .rshud_as_sf(spx)
+    sp_gcs <- sf::st_transform(sp_sf, 4326)
+    bb <- sf::st_bbox(sp_gcs)
+    ext <- c(bb[["xmin"]], bb[["xmax"]], bb[["ymin"]], bb[["ymax"]])
   }
-  x0 = round(mean(ext[1:2]), 1)
-  y0 = round(mean(ext[1:2+2]), 1)
-  dx = round(diff(ext[1:2]), 2)
-  dy = round(diff(ext[1:2+2]), 2)
-  
-  ret = sp::CRS(paste0('+proj=', 'leac',
-                       ' +lat_1=', y0,
-                       ' +lon_0=', x0,
-                       ' +datum=', 'WGS84',
-                       " +units=", "m"))
+
+  x0 <- round(mean(ext[1:2]), 1)
+  y0 <- round(mean(ext[3:4]), 1)
+
+  ret <- sf::st_crs(paste0(
+    "+proj=leac",
+    " +lat_1=", y0,
+    " +lon_0=", x0,
+    " +datum=WGS84",
+    " +units=m"
+  ))
   return(ret)
 }
 
@@ -93,14 +97,13 @@ crs.long2utm <- function(lon, lat=30){
   }else{
     zid =crs.long2utmZone(lon)
     if(lat>=0){
-      str = paste0('+proj=utm +zone=', zid, ' +datum=WGS84 +units=m +no_defs')
+      str = paste0("+proj=utm +zone=", zid, " +datum=WGS84 +units=m +no_defs")
     }else{
-      str = paste0('+proj=utm +zone=', zid, ' +south +datum=WGS84 +units=m +no_defs')
+      str = paste0("+proj=utm +zone=", zid, " +south +datum=WGS84 +units=m +no_defs")
     }
-    x = sp::CRS(str)
+    x = sf::st_crs(str)
   }
   return(x)
 }
-
 
 

--- a/R/spatial_modern.R
+++ b/R/spatial_modern.R
@@ -1,0 +1,66 @@
+.rshud_as_crs <- function(crs) {
+  if (is.null(crs)) return(sf::NA_crs_)
+  if (inherits(crs, "crs")) return(crs)
+  if (is.numeric(crs) && length(crs) == 1 && is.finite(crs)) return(sf::st_crs(crs))
+  if (is.character(crs) && length(crs) == 1 && nzchar(crs)) return(sf::st_crs(crs))
+  if (inherits(crs, "CRS")) {
+    if (!requireNamespace("sp", quietly = TRUE)) {
+      stop("sp is required to convert sp::CRS -> sf::crs")
+    }
+    return(sf::st_crs(sp::proj4string(crs)))
+  }
+  stop("Unsupported CRS format: ", paste(class(crs), collapse = "/"))
+}
+
+.rshud_crs_wkt <- function(crs) {
+  crs_sf <- .rshud_as_crs(crs)
+  if (is.na(crs_sf)) return(NA_character_)
+  if (!is.null(crs_sf$wkt) && nzchar(crs_sf$wkt)) return(crs_sf$wkt)
+  if (!is.null(crs_sf$proj4string) && nzchar(crs_sf$proj4string)) return(crs_sf$proj4string)
+  NA_character_
+}
+
+.rshud_as_sf <- function(x) {
+  if (is.null(x)) return(NULL)
+  if (inherits(x, "sf")) return(x)
+  if (inherits(x, "sfc")) return(sf::st_sf(geometry = x))
+  if (inherits(x, "SpatVector")) return(sf::st_as_sf(x))
+  if (any(grepl("^Spatial", class(x)))) return(sf::st_as_sf(x))
+  stop("Unsupported spatial object: ", paste(class(x), collapse = "/"))
+}
+
+.rshud_as_spatvector <- function(x, crs = NULL) {
+  if (inherits(x, "SpatVector")) {
+    v <- x
+  } else if (inherits(x, "sfc")) {
+    v <- terra::vect(sf::st_sf(geometry = x))
+  } else {
+    v <- terra::vect(x)
+  }
+  if (!is.null(crs)) {
+    wkt <- .rshud_crs_wkt(crs)
+    if (!is.na(wkt)) terra::crs(v) <- wkt
+  }
+  v
+}
+
+.rshud_geom_drop_holes <- function(g) {
+  gt <- as.character(sf::st_geometry_type(g, by_geometry = TRUE))
+  if (length(gt) == 0) return(g)
+  gt <- gt[[1]]
+
+  if (gt == "POLYGON") {
+    if (length(g) == 0) return(g)
+    return(sf::st_polygon(list(g[[1]])))
+  }
+  if (gt == "MULTIPOLYGON") {
+    if (length(g) == 0) return(g)
+    polys <- lapply(g, function(poly) {
+      if (length(poly) == 0) return(poly)
+      list(poly[[1]])
+    })
+    return(sf::st_multipolygon(polys))
+  }
+  g
+}
+

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,5 @@
+library(testthat)
+library(rSHUD)
+
+test_check("rSHUD")
+

--- a/tests/testthat/test-modern-spatial.R
+++ b/tests/testthat/test-modern-spatial.R
@@ -1,0 +1,73 @@
+test_that("fishnet polygon returns sf", {
+  xx <- seq(0, 2, by = 1)
+  yy <- seq(0, 2, by = 1)
+  fn <- fishnet(xx = xx, yy = yy, crs = 4326, type = "polygon")
+  expect_s3_class(fn, "sf")
+  expect_equal(nrow(fn), 4)
+  expect_true(all(c("xmin", "xmax", "ymin", "ymax", "xcenter", "ycenter") %in% names(fn)))
+  expect_equal(sf::st_crs(fn)$epsg, 4326)
+  expect_true(all(sf::st_geometry_type(fn) == "POLYGON"))
+})
+
+test_that("fishnet points returns sf", {
+  xx <- 1:3
+  yy <- 1:2
+  fn <- fishnet(xx = xx, yy = yy, crs = 4326, type = "point")
+  expect_s3_class(fn, "sf")
+  expect_equal(nrow(fn), length(xx) * length(yy))
+  expect_true(all(sf::st_geometry_type(fn) == "POINT"))
+})
+
+test_that("xy2shp creates sf geometries", {
+  pts <- matrix(c(0, 0, 1, 2), ncol = 2, byrow = TRUE)
+  s <- xy2shp(pts, df = data.frame(ID = 1:2), crs = 4326, shape = "points")
+  expect_s3_class(s, "sf")
+  expect_equal(nrow(s), 2)
+  expect_true(all(sf::st_geometry_type(s) == "POINT"))
+
+  ln <- list(matrix(c(0, 0, 1, 1, 2, 0), ncol = 2, byrow = TRUE))
+  s2 <- xy2shp(ln, df = data.frame(ID = 1), crs = 4326, shape = "lines")
+  expect_s3_class(s2, "sf")
+  expect_true(all(sf::st_geometry_type(s2) == "LINESTRING"))
+})
+
+test_that("removeholes drops interior rings for sf polygons", {
+  outer <- matrix(c(0, 0, 0, 10, 10, 10, 10, 0, 0, 0), ncol = 2, byrow = TRUE)
+  hole <- matrix(c(3, 3, 7, 3, 7, 7, 3, 7, 3, 3), ncol = 2, byrow = TRUE)
+  p <- sf::st_polygon(list(outer, hole))
+  x <- sf::st_sf(geometry = sf::st_sfc(p, crs = 4326))
+  y <- removeholes(x)
+  expect_s3_class(y, "sf")
+  expect_equal(length(sf::st_geometry(y)[[1]]), 1)
+})
+
+test_that("ForcingCoverage returns one polygon per site", {
+  wbd_ring <- matrix(c(0, 0, 0, 10, 10, 10, 10, 0, 0, 0), ncol = 2, byrow = TRUE)
+  wbd <- sf::st_sf(geometry = sf::st_sfc(sf::st_polygon(list(wbd_ring)), crs = 4326))
+
+  sites <- sf::st_as_sf(
+    data.frame(ID = c(1, 2), x = c(2, 8), y = c(2, 8)),
+    coords = c("x", "y"),
+    crs = 4326
+  )
+
+  fc <- ForcingCoverage(sp.meteoSite = sites, pcs = 4326, dem = NULL, wbd = wbd, enlarge = 0)
+  expect_s3_class(fc, "sf")
+  expect_equal(nrow(fc), 2)
+  expect_true(all(c("ID", "Lon", "Lat", "X", "Y", "Z", "Filename") %in% names(fc)))
+  expect_true(all(sf::st_geometry_type(fc) == "POLYGON"))
+})
+
+test_that("xyz2Raster returns terra SpatRaster", {
+  x <- c(0, 1, 2)
+  y <- c(10, 11)
+  arr <- matrix(1:6, nrow = 3, ncol = 2)
+  r <- xyz2Raster(x = x, y = y, arr = arr, flip = TRUE, plot = FALSE)
+  expect_true(inherits(r, "SpatRaster"))
+  expect_equal(terra::ncol(r), length(x))
+  expect_equal(terra::nrow(r), length(y))
+
+  arr3 <- array(1:(3 * 2 * 2), dim = c(3, 2, 2))
+  r2 <- xyz2Raster(x = x, y = y, arr = arr3, flip = TRUE, plot = FALSE)
+  expect_equal(terra::nlyr(r2), 2)
+})


### PR DESCRIPTION
Closes #1.

## Summary
- Refactor key GIS APIs to run on `sf` (vector) + `terra` (raster)
- Add internal helpers for CRS/object conversion
- Add `testthat` smoke tests

## Key changes
- `writeshape()` now writes via `terra::writeVector()` and accepts sf/terra/sp inputs
- `fishnet()`, `xy2shp()`, `removeholes()`, `ForcingCoverage()` now work without legacy spatial stack
- `ProjectCoordinate()` now uses `sf` transforms (drops `proj4` runtime dependency)
- `xyz2Raster()` now returns a `terra` `SpatRaster`

## Tests
- `R CMD INSTALL --install-tests .`
- `testthat::test_package('rSHUD')`
