### PR TITLE
fix: snap simplified coords back to original ref in FromToNode (#8)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Remotes: shulele/RTriangle/pkg
 Suggests: testthat,
     knitr,
     rmarkdown,
+    RANN,
   deldir,
   interp,
   whitebox,

--- a/tests/testthat/test-fromtonode-snap.R
+++ b/tests/testthat/test-fromtonode-snap.R
@@ -1,0 +1,85 @@
+test_that("snap_coords_to_ref restores exact coord_ref values", {
+  skip_if_not_installed("sp")
+
+  pts <- matrix(
+    c(
+      1000000.123, 2000000.456,
+      1000001.234, 2000001.567,
+      1000002.345, 2000002.678,
+      1000003.456, 2000003.789
+    ),
+    ncol = 2,
+    byrow = TRUE
+  )
+
+  sl <- sp::SpatialLines(list(sp::Lines(list(sp::Line(pts)), ID = "1")))
+  coord_ref <- extractCoords(sl, unique = TRUE)
+
+  sl_drift <- sl
+  eps <- 1e-9
+  sl_drift@lines[[1]]@Lines[[1]]@coords[, 1:2] <-
+    sl_drift@lines[[1]]@Lines[[1]]@coords[, 1:2] + eps
+
+  tol <- 1e-6
+  snapped <- rSHUD:::snap_coords_to_ref(sl_drift, coord_ref = coord_ref, tol = tol)
+  coords_snapped <- snapped@lines[[1]]@Lines[[1]]@coords[, 1:2, drop = FALSE]
+
+  expect_equal(coords_snapped, pts)
+})
+
+test_that("FromToNode simplify returns non-zero Fr/To nodes", {
+  skip_if_not_installed("sp")
+  skip_if_not_installed("raster")
+  skip_if_not_installed("rgeos")
+
+  make_line <- function(from, to, n, noise_sd = 0.01) {
+    xy <- cbind(
+      seq(from[1], to[1], length.out = n),
+      seq(from[2], to[2], length.out = n)
+    )
+    xy <- xy + matrix(stats::rnorm(n * 2, sd = noise_sd), ncol = 2)
+    xy[1, ] <- from
+    xy[n, ] <- to
+    xy
+  }
+
+  set.seed(1)
+  p0 <- c(1000000.123, 2000000.456)
+  p1 <- c(1000100.789, 1999900.321)
+  p2 <- c(1000200.321, 1999800.987)
+  p3 <- c(1000050.555, 1999850.111)
+
+  seg1 <- make_line(p0, p1, n = 50)
+  seg2 <- make_line(p1, p2, n = 60)
+  seg3 <- make_line(p1, p3, n = 40)
+
+  sl <- sp::SpatialLines(list(
+    sp::Lines(list(sp::Line(seg1)), ID = "1"),
+    sp::Lines(list(sp::Line(seg2)), ID = "2"),
+    sp::Lines(list(sp::Line(seg3)), ID = "3")
+  ))
+
+  coord_ref <- extractCoords(sl, unique = TRUE)
+  ft <- FromToNode(sl, coord = coord_ref, simplify = TRUE)
+
+  expect_true(all(ft[, "FrNode"] > 0))
+  expect_true(all(ft[, "ToNode"] > 0))
+  expect_true(all(ft[, "FrNode"] <= nrow(coord_ref)))
+  expect_true(all(ft[, "ToNode"] <= nrow(coord_ref)))
+
+  pt.list <- unlist(sp::coordinates(sl), recursive = FALSE)
+  expect_equal(length(pt.list), length(sl))
+
+  fr_true <- do.call(rbind, lapply(pt.list, function(x) x[1, 1:2, drop = FALSE]))
+  to_true <- do.call(rbind, lapply(pt.list, function(x) x[nrow(x), 1:2, drop = FALSE]))
+  fr <- coord_ref[ft[, "FrNode"], , drop = FALSE]
+  to <- coord_ref[ft[, "ToNode"], , drop = FALSE]
+
+  dimnames(fr) <- NULL
+  dimnames(fr_true) <- NULL
+  dimnames(to) <- NULL
+  dimnames(to_true) <- NULL
+
+  expect_equal(fr, fr_true)
+  expect_equal(to, to_true)
+})


### PR DESCRIPTION
## 问题

`FromToNode(..., simplify=TRUE)` 在 `force(coord)` 修复（#6）后，`gSimplify` 引入 ~1e-9 坐标漂移导致 `xy2ID/rowMatch` 严格相等匹配全部返回 0，`shud.river()` 崩溃。

详见 #8。

## 方案

在 `FromToNode` 的 simplify 分支中，`gSimplify` 之后、`NodeIDList` 之前，对简化后的几何顶点做最近邻 snap 回原 coord 的精确值。

### 新增 `snap_coords_to_ref(sp_simplified, coord_ref, tol)`

- 优先用 `RANN::nn2`（kd-tree，O(N log M)）
- Fallback：网格哈希 + 邻桶向量化距离（无外部依赖）
- 距离 <= tol 的顶点替换为 coord_ref 精确值，>tol 保持原值

### 改动

- `R/GIS_RiverProcess.R`：新增 `snap_coords_to_ref()`，`FromToNode` simplify 分支插入 snap 步骤
- `DESCRIPTION`：RANN 加入 Suggests
- `tests/testthat/test-fromtonode-snap.R`：回归测试

### 不改动

- `xy2ID`/`rowMatch`：严格相等语义不变
- 所有调用点（`shud.river`、`sp.RiverDown` 等）：无需修改

## 验证

- QHH 1633 河段：snap 耗时 0.347s
- snap 后 sp.riv 与 baseline 完全一致：
  - Down/Type/BC/Length/Slope：1633/1633 (100%)
  - @point 位移：0
  - cor(Slope, slope_true) = 1.0
- 回归测试通过（合成河网 + FromToNode simplify=TRUE 端点索引非 0）

Closes #8